### PR TITLE
build: Add default envrc file

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+strict_env
+source_env_if_exists .envrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ dist/
 *.tar
 
 demodata/
+.envrc.local


### PR DESCRIPTION
This allows for devs to set up asdf, etc in their local file, e.g.

```
echo use asdf >> .envrc.local
```

will set up asdf using direnv (which of course needs to be preconfigured).