### PR TITLE
refactor: shim demo fixups

### DIFF
--- a/hack/demo.sh
+++ b/hack/demo.sh
@@ -222,14 +222,14 @@ kind delete clusters image-credential-provider-test || true
 kind create cluster --config="${DEMODATA_DIR}/kind-config.yaml" --name image-credential-provider-test
 
 docker image pull nginx:latest
-docker image tag docker.io/library/nginx:latest "localhost:${REGISTRY_PORT}/library/nginx:latest"
+docker image tag docker.io/library/nginx:latest "0.0.0.0:${REGISTRY_PORT}/library/nginx:latest"
 
-echo "${REGISTRY_PASSWORD}" | docker login -u "${REGISTRY_USERNAME}" --password-stdin "localhost:${REGISTRY_PORT}"
-docker image push "localhost:${REGISTRY_PORT}/library/nginx:latest"
+echo "${REGISTRY_PASSWORD}" | docker login -u "${REGISTRY_USERNAME}" --password-stdin "0.0.0.0:${REGISTRY_PORT}"
+docker image push "0.0.0.0:${REGISTRY_PORT}/library/nginx:latest"
 
 # Retag and push with a tag that doesn't exist in docker.io to test Containerd mirror config
-docker image tag docker.io/library/nginx:latest "localhost:${REGISTRY_PORT}/library/nginx:$(whoami)"
-docker image push "localhost:${REGISTRY_PORT}/library/nginx:$(whoami)"
+docker image tag docker.io/library/nginx:latest "0.0.0.0:${REGISTRY_PORT}/library/nginx:$(whoami)"
+docker image push "0.0.0.0:${REGISTRY_PORT}/library/nginx:$(whoami)"
 
 # Wait for KIND to startup
 sleep 10s

--- a/hack/demo.sh
+++ b/hack/demo.sh
@@ -217,14 +217,14 @@ kind delete clusters image-credential-provider-test || true
 kind create cluster --config="${DEMODATA_DIR}/kind-config.yaml" --name image-credential-provider-test
 
 docker image pull nginx:latest
-docker image tag docker.io/library/nginx:latest "0.0.0.0:${REGISTRY_PORT}/library/nginx:latest"
+docker image tag docker.io/library/nginx:latest "localhost:${REGISTRY_PORT}/library/nginx:latest"
 
-echo "${REGISTRY_PASSWORD}" | docker login -u "${REGISTRY_USERNAME}" --password-stdin "0.0.0.0:${REGISTRY_PORT}"
-docker image push "0.0.0.0:${REGISTRY_PORT}/library/nginx:latest"
+echo "${REGISTRY_PASSWORD}" | docker login -u "${REGISTRY_USERNAME}" --password-stdin "localhost:${REGISTRY_PORT}"
+docker image push "localhost:${REGISTRY_PORT}/library/nginx:latest"
 
 # Retag and push with a tag that doesn't exist in docker.io to test Containerd mirror config
-docker image tag docker.io/library/nginx:latest "0.0.0.0:${REGISTRY_PORT}/library/nginx:$(whoami)"
-docker image push "0.0.0.0:${REGISTRY_PORT}/library/nginx:$(whoami)"
+docker image tag docker.io/library/nginx:latest "localhost:${REGISTRY_PORT}/library/nginx:$(whoami)"
+docker image push "localhost:${REGISTRY_PORT}/library/nginx:$(whoami)"
 
 # Wait for KIND to startup
 sleep 10s


### PR DESCRIPTION
The first commit fixes the script on my Mac, not sure if this will break on Linux.
The second commit changes the demo script so it uses the `static-credential-provider` binary.

```
➜  hack git:(jimmi/implement-shim) ✗ ./demo.sh
...
pod/nginx-latest created
pod/nginx-mirror created
pod/nginx-stable created
pod/nginx-latest condition met
pod/nginx-stable condition met
pod/nginx-mirror condition met
➜  hack git:(jimmi/implement-shim) ✗ k get pods -A
NAMESPACE            NAME                                                                   READY   STATUS    RESTARTS   AGE
default              nginx-latest                                                           1/1     Running   0          15s
default              nginx-mirror                                                           1/1     Running   0          15s
default              nginx-stable                                                           1/1     Running   0          15s
kube-system          coredns-565d847f94-4z6vh                                               1/1     Running   0          22s
kube-system          coredns-565d847f94-rg4dm                                               1/1     Running   0          22s
kube-system          etcd-image-credential-provider-test-control-plane                      1/1     Running   0          37s
kube-system          kindnet-fnrgj                                                          1/1     Running   0          22s
kube-system          kube-apiserver-image-credential-provider-test-control-plane            1/1     Running   0          36s
kube-system          kube-controller-manager-image-credential-provider-test-control-plane   1/1     Running   0          36s
kube-system          kube-proxy-cxw7h                                                       1/1     Running   0          22s
kube-system          kube-scheduler-image-credential-provider-test-control-plane            1/1     Running   0          37s
local-path-storage   local-path-provisioner-684f458cdd-mvlc9                                1/1     Running   0          22s
````