### PR TITLE
fix: Correctly handle MirrorCredenialsOnly strategy

### DIFF
--- a/pkg/credentialprovider/shim/testdata/config-with-mirror.yaml
+++ b/pkg/credentialprovider/shim/testdata/config-with-mirror.yaml
@@ -8,7 +8,7 @@ mirror:
   credentialsStrategy: MirrorCredentialsFirst
 credentialProviderPluginBinDir: testdata
 credentialProviders:
-  apiVersion: kubelet.config.k8s.io/v1beta2
+  apiVersion: kubelet.config.k8s.io/v1beta1
   kind: CredentialProviderConfig
   providers:
   - name: staticcredentialprovider-v1alpha1.sh

--- a/pkg/credentialprovider/shim/testdata/config.yaml
+++ b/pkg/credentialprovider/shim/testdata/config.yaml
@@ -5,7 +5,7 @@ apiVersion: config.kubeletimagecredentialprovidershim.d2iq.com/v1alpha1
 kind: KubeletImageCredentialProviderShimConfig
 credentialProviderPluginBinDir: testdata
 credentialProviders:
-  apiVersion: kubelet.config.k8s.io/v1beta2
+  apiVersion: kubelet.config.k8s.io/v1beta1
   kind: CredentialProviderConfig
   providers:
   - name: staticcredentialprovider-v1alpha1.sh


### PR DESCRIPTION
A bug in previous configuration meant that no credentials would ever
have been returned when using `MirrorCredentialsOnly`.
