### PR TITLE
fix: Use closest authconfig match

### DIFF
--- a/pkg/credentialprovider/shim/testdata/staticcredentialprovider-v1alpha1.sh
+++ b/pkg/credentialprovider/shim/testdata/staticcredentialprovider-v1alpha1.sh
@@ -12,6 +12,6 @@ echo '{
   "cacheKeyType":"Image",
   "cacheDuration":"10s",
   "auth":{
-    "registry:5000": {"username":"v1alpha1user","password":"v1alpha1password"}
+    "*.v1alpha1": {"username":"v1alpha1user","password":"v1alpha1password"}
   }
 }'

--- a/pkg/credentialprovider/shim/testdata/staticcredentialprovider-v1beta1.sh
+++ b/pkg/credentialprovider/shim/testdata/staticcredentialprovider-v1beta1.sh
@@ -12,6 +12,6 @@ echo '{
   "cacheKeyType":"Image",
   "cacheDuration":"5s",
   "auth":{
-    "registry:5000": {"username":"v1beta1user","password":"v1beta1password"}
+    "*.v1beta1": {"username":"v1beta1user","password":"v1beta1password"}
   }
 }'


### PR DESCRIPTION
Previously this was using the first one found, which was
non-deterministic because it was traversing map keys.
