### PR TITLE
ci: fix e2e-test in Darwin by always building with GOOS=linux

### DIFF
--- a/make/go.mk
+++ b/make/go.mk
@@ -81,7 +81,7 @@ E2E_FLAKE_ATTEMPTS ?= 1
 e2e-test: ## Runs e2e tests
 e2e-test: install-tool.golang install-tool.ginkgo
 ifneq ($(SKIP_BUILD),true)
-e2e-test: build-snapshot
+	$(MAKE) GOOS=linux build-snapshot
 endif
 	$(info $(M) running e2e tests$(if $(E2E_LABEL), labelled "$(E2E_LABEL)")$(if $(E2E_FOCUS), matching "$(E2E_FOCUS)"))
 	ginkgo run \


### PR DESCRIPTION
Always build Linux binaries when running e2e tests.