### PR TITLE
refactor(e2e): Use ginkgo and gomega functions in helper libs

### DIFF
--- a/test/e2e/cluster/kind.go
+++ b/test/e2e/cluster/kind.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/docker/docker/pkg/namesgenerator"
+	g "github.com/onsi/ginkgo/v2"
+	gm "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -29,13 +31,11 @@ type kindCluster struct {
 }
 
 // NewKinDCluster creates a KinD cluster and returns a Cluster ready to be used.
-//
-//nolint:revive // Complex function is ok in this test file.
 func NewKinDCluster(
 	ctx context.Context,
 	providerOpts []cluster.ProviderOption,
 	createOpts []cluster.CreateOption,
-) (Cluster, string, error) {
+) (kc Cluster, kubeconfig string) {
 	seedrng.EnsureSeeded()
 
 	name := strings.ReplaceAll(namesgenerator.GetRandomName(0), "_", "-")
@@ -45,14 +45,13 @@ func NewKinDCluster(
 	// Do not export kubeconfig to file by default, makes cleanup easier. This can be overridden by using create option
 	// to configure this via `cluster.CreateWithKubeconfigPath` when calling `NewKindCluster`.
 	tempDir, err := os.MkdirTemp("", fmt.Sprintf("%s-kubeconfig-*", name))
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to create temp dir: %w", err)
-	}
-	defer os.RemoveAll(tempDir)
+	gm.Expect(err).NotTo(gm.HaveOccurred())
+	g.DeferCleanup(os.RemoveAll, tempDir)
 	tempKubeconfig := filepath.Join(tempDir, "kubeconfig")
 	mergedCreateOpts := []cluster.CreateOption{cluster.CreateWithKubeconfigPath(tempKubeconfig)}
 	mergedCreateOpts = append(mergedCreateOpts, createOpts...)
 
+	g.DeferCleanup(provider.Delete, name, "")
 	kindClusterErr := make(chan error, 1)
 	go func() {
 		kindClusterErr <- provider.Create(name, mergedCreateOpts...)
@@ -60,40 +59,19 @@ func NewKinDCluster(
 
 	select {
 	case <-ctx.Done():
-		if err := provider.Delete(name, ""); err != nil {
-			return nil, "", fmt.Errorf("failed to delete KinD cluster after spec timeout: %w", err)
-		}
-		return nil, "", nil
+		return nil, ""
 	case err := <-kindClusterErr:
-		if err != nil {
-			return nil, "", fmt.Errorf("failed to create KinD cluster: %w", err)
-		}
+		gm.Expect(err).NotTo(gm.HaveOccurred())
 	}
 
-	const warningDeleteKinD = "WARNING: failed to delete KinD cluster: %v"
-	kubeconfig, err := provider.KubeConfig(name, false)
-	if err != nil {
-		if deleteErr := provider.Delete(name, ""); deleteErr != nil {
-			_, _ = fmt.Fprintf(os.Stderr, warningDeleteKinD, deleteErr)
-		}
-		return nil, "", fmt.Errorf("failed to retrieve kubeconfig: %w", err)
-	}
+	kubeconfig, err = provider.KubeConfig(name, false)
+	gm.Expect(err).NotTo(gm.HaveOccurred())
 
 	restConfig, err := clientcmd.RESTConfigFromKubeConfig([]byte(kubeconfig))
-	if err != nil {
-		if deleteErr := provider.Delete(name, ""); deleteErr != nil {
-			_, _ = fmt.Fprintf(os.Stderr, warningDeleteKinD, deleteErr)
-		}
-		return nil, "", fmt.Errorf("failed to build REST config from kubeconfig: %w", err)
-	}
+	gm.Expect(err).NotTo(gm.HaveOccurred())
 
 	kubeClient, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		if deleteErr := provider.Delete(name, ""); deleteErr != nil {
-			_, _ = fmt.Fprintf(os.Stderr, warningDeleteKinD, deleteErr)
-		}
-		return nil, "", fmt.Errorf("failed to create Kubernetes client: %w", err)
-	}
+	gm.Expect(err).NotTo(gm.HaveOccurred())
 
 	err = wait.PollInfiniteWithContext(ctx, time.Second*1, func(ctx context.Context) (bool, error) {
 		_, getSAErr := kubeClient.CoreV1().ServiceAccounts(metav1.NamespaceDefault).
@@ -106,17 +84,12 @@ func NewKinDCluster(
 		}
 		return false, getSAErr
 	})
-	if err != nil {
-		if err := provider.Delete(name, ""); err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, warningDeleteKinD, err)
-		}
-		return nil, "", fmt.Errorf("failed to wait for default service account to exist: %w", err)
-	}
+	gm.Expect(err).NotTo(gm.HaveOccurred())
 
 	return &kindCluster{
 		name:     name,
 		provider: provider,
-	}, kubeconfig, nil
+	}, kubeconfig
 }
 
 func (c *kindCluster) Delete(context.Context) error {

--- a/test/e2e/docker/client.go
+++ b/test/e2e/docker/client.go
@@ -11,10 +11,13 @@ import (
 	"io"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
+	g "github.com/onsi/ginkgo/v2"
+	gm "github.com/onsi/gomega"
 )
 
 var (
@@ -48,11 +51,9 @@ func RunContainerInBackground(
 	containerCfg *container.Config,
 	hostCfg *container.HostConfig,
 	pullUsername, pullPassword string,
-) (containerInspect types.ContainerJSON, cleanup func(context.Context) error, err error) {
+) types.ContainerJSON {
 	dClient, err := ClientFromEnv()
-	if err != nil {
-		return types.ContainerJSON{}, nil, err
-	}
+	gm.Expect(err).NotTo(gm.HaveOccurred())
 
 	if hostCfg.NetworkMode.IsUserDefined() {
 		_, err = dClient.NetworkInspect(
@@ -72,59 +73,30 @@ func RunContainerInBackground(
 					},
 				},
 			)
-			if err != nil {
-				return types.ContainerJSON{}, nil, fmt.Errorf(
-					"failed to create Docker network %q for container: %w",
-					hostCfg.NetworkMode.NetworkName(),
-					err,
-				)
-			}
 		}
+		gm.Expect(err).NotTo(gm.HaveOccurred())
 	}
 
 	out, err := dClient.ImagePull(ctx, containerCfg.Image, types.ImagePullOptions{})
-	if err != nil {
-		return types.ContainerJSON{}, nil, fmt.Errorf(
-			"failed to pull image %q: %w",
-			containerCfg.Image,
-			err,
-		)
-	}
+	gm.Expect(err).NotTo(gm.HaveOccurred())
 	defer out.Close()
 	_, _ = io.Copy(os.Stderr, out)
 
 	created, err := dClient.ContainerCreate(ctx, containerCfg, hostCfg, nil, nil, containerName)
-	if err != nil {
-		return types.ContainerJSON{}, nil, fmt.Errorf("failed to create container: %w", err)
-	}
+	gm.Expect(err).NotTo(gm.HaveOccurred())
 	containerID := created.ID
 
-	cleanup = func(ctx context.Context) error {
-		return ForceDeleteContainer(ctx, containerID)
-	}
+	g.DeferCleanup(func(ctx g.SpecContext, containerID string) {
+		gm.Expect(ForceDeleteContainer(ctx, containerID)).To(gm.Succeed())
+	}, containerID, g.NodeTimeout(time.Minute))
 
-	err = dClient.ContainerStart(ctx, containerID, types.ContainerStartOptions{})
-	if err != nil {
-		if deleteErr := cleanup(ctx); deleteErr != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "WARNING: failed to delete container: %v", deleteErr)
-		}
+	gm.Expect(dClient.ContainerStart(ctx, containerID, types.ContainerStartOptions{})).
+		To(gm.Succeed())
 
-		return types.ContainerJSON{}, nil, fmt.Errorf("failed to start container: %w", err)
-	}
+	containerInspect, err := dClient.ContainerInspect(ctx, containerID)
+	gm.Expect(err).NotTo(gm.HaveOccurred())
 
-	containerInspect, err = dClient.ContainerInspect(ctx, containerID)
-	if err != nil {
-		if deleteErr := cleanup(ctx); deleteErr != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "WARNING: failed to delete container: %v", deleteErr)
-		}
-
-		return types.ContainerJSON{}, nil, fmt.Errorf(
-			"failed to inspect started container: %w",
-			err,
-		)
-	}
-
-	return containerInspect, cleanup, nil
+	return containerInspect
 }
 
 func ForceDeleteContainer(ctx context.Context, containerID string) error {

--- a/test/e2e/suites/mirror/mirror_suite_test.go
+++ b/test/e2e/suites/mirror/mirror_suite_test.go
@@ -74,11 +74,7 @@ func testdataPath(f string) string {
 var _ = SynchronizedBeforeSuite(
 	func(ctx SpecContext) []byte {
 		By("Starting Docker registry")
-		mirrorRegistry, err := registry.NewRegistry(ctx)
-		Expect(err).ShouldNot(HaveOccurred())
-		DeferCleanup(func(ctx SpecContext) error {
-			return mirrorRegistry.Delete(ctx)
-		}, NodeTimeout(time.Second))
+		mirrorRegistry := registry.NewRegistry(ctx)
 
 		By("Setting up kubelet credential providers")
 		providerBinDir := GinkgoT().TempDir()
@@ -145,7 +141,7 @@ var _ = SynchronizedBeforeSuite(
 		)).To(Succeed())
 
 		By("Starting KinD cluster")
-		kindCluster, kubeconfig, err := cluster.NewKinDCluster(
+		_, kubeconfig := cluster.NewKinDCluster(
 			ctx,
 			[]kindcluster.ProviderOption{kindcluster.ProviderWithDocker()},
 			[]kindcluster.CreateOption{
@@ -183,10 +179,6 @@ var _ = SynchronizedBeforeSuite(
 				}),
 			},
 		)
-		Expect(err).ShouldNot(HaveOccurred())
-		DeferCleanup(func(ctx SpecContext) error {
-			return kindCluster.Delete(ctx)
-		}, NodeTimeout(time.Minute))
 
 		configBytes, _ := json.Marshal(e2eSetupConfig{
 			Registry: e2eRegistryConfig{


### PR DESCRIPTION
Not sure how I feel about this but I moved a lot of the ginkgo/gomega calls into the e2e helper libs. This makes cleanup etc easier but then has a different flow to "normal" go usage, i.e. no errors are returned from helpers, all handled in the helpers themselves. What do you think @dkoshkin? 